### PR TITLE
Use state store for textbox validation

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -3,6 +3,8 @@
 // Sveltekit typeScript docs https://kit.svelte.dev/docs/typescript
 // Importing types discussion https://github.com/sveltejs/kit/discussions/3772#discussioncomment-2131563
 
+import * as _journey from '$lib/types/journey';
+
 declare global {
 	declare namespace App {
 		interface Locals {
@@ -15,6 +17,9 @@ declare global {
 
 		//interface Stuff {}
 	}
+
+	// State is expected to be used frequently across the application, remove the need for references
+	type StateStoreType = _journey.StateStoreType;
 }
 
 // TODO: Add whatever is needed to facilitate authentication and authorisation

--- a/src/lib/components/Framework/Page.svelte
+++ b/src/lib/components/Framework/Page.svelte
@@ -4,6 +4,7 @@
 	import { goto } from '$app/navigation';
 	import { DISABLEVALIDATION } from '$lib/env';
 	import { actionStore } from '$lib/stores/actionstore';
+	import { state } from '$lib/stores/statestore';
 	import { validationStore } from '$lib/stores/validationstore';
 	import { valueStore } from '$lib/stores/valuestore';
 	import { nextPageUrl, prevPageUrl } from '$lib/utils/navigation';
@@ -37,9 +38,14 @@
 	function nextPage() {
 		if (DISABLEVALIDATION != 'Y' && !pageValid(page, $valueStore, $validationStore)) {
 			console.debug('Page invalid, correct before trying again');
-			const first_error = first_invalid_component_in_page(page, $valueStore, $validationStore);
-			if (first_error != undefined) {
-				goto(`#${first_error}`);
+			const error_comp_id = first_invalid_component_in_page(page, $valueStore, $validationStore);
+			if (error_comp_id != undefined) {
+				state.set(error_comp_id, {
+					value: $state[error_comp_id]?.value ?? '',
+					display: $state[error_comp_id]?.display ?? '',
+					valid: false
+				});
+				goto(`#${error_comp_id}`, {replaceState: true});
 			}
 			return;
 		}

--- a/src/lib/components/Framework/Page.svelte
+++ b/src/lib/components/Framework/Page.svelte
@@ -45,7 +45,7 @@
 					display: $state[error_comp_id]?.display ?? '',
 					valid: false
 				});
-				goto(`#${error_comp_id}`, {replaceState: true});
+				goto(`#${error_comp_id}`, { replaceState: true });
 			}
 			return;
 		}

--- a/src/lib/components/InputTextbox.svelte
+++ b/src/lib/components/InputTextbox.svelte
@@ -72,7 +72,7 @@
 
 	<div class="container">
 		{#if component.label}
-			<label for="{component.id}-input">
+			<label for="{component.id}~">
 				{component.label}
 				{#if component.required}
 					<span class="required">*</span>
@@ -84,7 +84,7 @@
 			<input
 				type={html5type}
 				class={component.type?.toLowerCase()}
-				id="{component.id}-input"
+				id="{component.id}~"
 				name={component.id}
 				placeholder={component.placeholder ?? ''}
 				required={component.required ?? false}

--- a/src/lib/components/InputTextbox.svelte
+++ b/src/lib/components/InputTextbox.svelte
@@ -4,7 +4,6 @@
 	import { createEventDispatcher } from 'svelte';
 	import { state } from '$lib/stores/statestore';
 	import Helptext from '$lib/components/Helptext.svelte';
-	import Address from './Address.svelte';
 
 	// expose component properties
 	export let component: InputComponent;

--- a/src/lib/components/InputTextbox.svelte
+++ b/src/lib/components/InputTextbox.svelte
@@ -4,6 +4,7 @@
 	import { createEventDispatcher } from 'svelte';
 	import { state } from '$lib/stores/statestore';
 	import Helptext from '$lib/components/Helptext.svelte';
+	import Address from './Address.svelte';
 
 	// expose component properties
 	export let component: InputComponent;
@@ -44,13 +45,17 @@
 	}
 	function act(event) {
 		state.set(component.id, {
-			value: event.target.value, 
-			display: component.type == 'Upper' ? event.target.value.toUpperCase() : event.target.value, 
+			value: event.target.value,
+			display: component.type == 'Upper' ? event.target.value.toUpperCase() : event.target.value,
 			valid: event.target.validity.valid
 		});
 		fallbackError = event.target.validity.valid ? '' : event.target.validationMessage;
 		// publish changes up to parent, for any additional actions
-		dispatch('valueChange', { key: component.id, value: event.target.value, valid: event.target.validity.valid });
+		dispatch('valueChange', {
+			key: component.id,
+			value: event.target.value,
+			valid: event.target.validity.valid
+		});
 	}
 	function focus() {
 		dispatch('focus', component.id);
@@ -58,6 +63,7 @@
 </script>
 
 <div
+	id={component.id}
 	class="component {active} {valid ? '' : 'invalid'}"
 	transition:blur
 	on:mouseenter={enter}
@@ -79,7 +85,7 @@
 			<input
 				type={html5type}
 				class={component.type?.toLowerCase()}
-				id={component.id}
+				id="{component.id}-input"
 				name={component.id}
 				placeholder={component.placeholder ?? ''}
 				required={component.required ?? false}

--- a/src/lib/components/InputTextbox.svelte
+++ b/src/lib/components/InputTextbox.svelte
@@ -72,7 +72,7 @@
 
 	<div class="container">
 		{#if component.label}
-			<label for={component.id}>
+			<label for="{component.id}-input">
 				{component.label}
 				{#if component.required}
 					<span class="required">*</span>

--- a/src/lib/components/InputTriboxdate.svelte
+++ b/src/lib/components/InputTriboxdate.svelte
@@ -216,7 +216,7 @@
 			class="hidden"
 		/>
 		{#if component.label}
-			<label for={component.id}>
+			<label for="{component.id}-input">
 				{component.label}
 				{#if component.required}
 					<span class="required">*</span>

--- a/src/lib/components/InputTriboxdate.svelte
+++ b/src/lib/components/InputTriboxdate.svelte
@@ -2,6 +2,7 @@
 	import type { TriBoxDateComponent } from '$lib/types/journey';
 	import { blur } from 'svelte/transition';
 	import { createEventDispatcher, onMount } from 'svelte';
+	import { state } from '$lib/stores/statestore';
 	import Helptext from '$lib/components/Helptext.svelte';
 
 	// expose component properties
@@ -9,7 +10,7 @@
 
 	// internal properties to support component logic
 	let fallbackError = 'Date entered is invalid';
-	let valid = true;
+	let valid: boolean = $state[component.id]?.valid ?? true;
 	let active = '';
 	let dateElem: HTMLInputElement; // TODO: rework this to use the hidden date field and HTML5 validation
 	let yearElem: HTMLInputElement;
@@ -178,6 +179,12 @@
 		// validate that this is an actual date and apply custom validation
 		validate();
 
+		state.set(component.id, {
+			value: component.value,
+			display: formatDate(),
+			valid: valid
+		});
+
 		// publish changes up to parent, let it handle state
 		dispatch('dateChange', {
 			key: component.id,
@@ -190,6 +197,7 @@
 </script>
 
 <div
+	id={component.id}
 	class="component {active} {valid ? '' : 'invalid'}"
 	transition:blur
 	on:mouseenter={enter}
@@ -201,7 +209,7 @@
 		<!-- Use date field (hidden) to take advantage of browser validator api -->
 		<input
 			type="date"
-			id={component.id}
+			id="{component.id}-input"
 			bind:value={component.value}
 			bind:this={dateElem}
 			required={component.required}

--- a/src/lib/components/InputTriboxdate.svelte
+++ b/src/lib/components/InputTriboxdate.svelte
@@ -209,14 +209,14 @@
 		<!-- Use date field (hidden) to take advantage of browser validator api -->
 		<input
 			type="date"
-			id="{component.id}-input"
+			id="{component.id}~"
 			bind:value={component.value}
 			bind:this={dateElem}
 			required={component.required}
 			class="hidden"
 		/>
 		{#if component.label}
-			<label for="{component.id}-input">
+			<label for="{component.id}~">
 				{component.label}
 				{#if component.required}
 					<span class="required">*</span>

--- a/src/lib/components/OptionButtons.svelte
+++ b/src/lib/components/OptionButtons.svelte
@@ -43,13 +43,13 @@
 
 	<input
 		type="hidden"
-		id="{component.id}-input"
+		id="{component.id}~"
 		bind:value={component.value}
 		required={component.required}
 	/>
 	<div class="container">
 		{#if component.label}
-			<label for="{component.id}-input">
+			<label for="{component.id}~">
 				{component.label}
 				{#if component.required}
 					<span class="required">*</span>

--- a/src/lib/components/OptionDropdown.svelte
+++ b/src/lib/components/OptionDropdown.svelte
@@ -54,7 +54,7 @@
 
 	<div class="container">
 		{#if component.label}
-			<label for="{component.id}-input">
+			<label for="{component.id}~">
 				{component.label}
 				{#if component.required}
 					<span class="required">*</span>
@@ -63,7 +63,7 @@
 		{/if}
 		{#if component.id}
 			<select
-				id="{component.id}-input"
+				id="{component.id}~"
 				name={component.id}
 				value={component.value}
 				data-reference={component.refdata}

--- a/src/lib/stores/statestore.ts
+++ b/src/lib/stores/statestore.ts
@@ -1,14 +1,9 @@
 // Alternative approach to valueStore + displayValueStore + validationStore, https://github.com/mtempleheald/journeyasdata/issues/103
+import type { StateRecordType, StateStoreType } from '$lib/types/journey';
 import { writable } from 'svelte/store';
 
-type StateType = {
-	key: string;
-	value: string;
-	display_value: string;
-	valid: boolean;
-};
 
-function upsert(store: { [key: string]: StateType }, key: string, state: StateType) {
+function upsert(store: StateStoreType, key: string, state: StateRecordType) {
 	// create new entry or overwrite regardless of what was set
 	store[key] = state;
 	return store;
@@ -19,8 +14,8 @@ function store() {
 
 	return {
 		subscribe,
-		set: (key: string, state: StateType) => update((store) => upsert(store, key, state)),
-		reset: (value: { [key: string]: StateType }) => set(value)
+		set: (key: string, state: StateRecordType) => update((store) => upsert(store, key, state)),
+		reset: (value: { [key: string]: StateRecordType }) => set(value)
 	};
 }
 

--- a/src/lib/stores/statestore.ts
+++ b/src/lib/stores/statestore.ts
@@ -1,9 +1,8 @@
 // Alternative approach to valueStore + displayValueStore + validationStore, https://github.com/mtempleheald/journeyasdata/issues/103
-import type { StateRecordType, StateStoreType } from '$lib/types/journey';
+import type { StateValueType, StateStoreType } from '$lib/types/journey';
 import { writable } from 'svelte/store';
 
-
-function upsert(store: StateStoreType, key: string, state: StateRecordType) {
+function upsert(store: StateStoreType, key: string, state: StateValueType) {
 	// create new entry or overwrite regardless of what was set
 	store[key] = state;
 	return store;
@@ -14,8 +13,8 @@ function store() {
 
 	return {
 		subscribe,
-		set: (key: string, state: StateRecordType) => update((store) => upsert(store, key, state)),
-		reset: (value: { [key: string]: StateRecordType }) => set(value)
+		set: (key: string, state: StateValueType) => update((store) => upsert(store, key, state)),
+		reset: (value: { [key: string]: StateValueType }) => set(value)
 	};
 }
 

--- a/src/lib/stores/statestore.ts
+++ b/src/lib/stores/statestore.ts
@@ -1,14 +1,8 @@
 // Alternative approach to valueStore + displayValueStore + validationStore, https://github.com/mtempleheald/journeyasdata/issues/103
+import type { StateValueType, StateStoreType } from '$lib/types/journey';
 import { writable } from 'svelte/store';
 
-type StateType = {
-	key: string;
-	value: string;
-	display_value: string;
-	valid: boolean;
-};
-
-function upsert(store: { [key: string]: StateType }, key: string, state: StateType) {
+function upsert(store: StateStoreType, key: string, state: StateValueType) {
 	// create new entry or overwrite regardless of what was set
 	store[key] = state;
 	return store;
@@ -19,8 +13,8 @@ function store() {
 
 	return {
 		subscribe,
-		set: (key: string, state: StateType) => update((store) => upsert(store, key, state)),
-		reset: (value: { [key: string]: StateType }) => set(value)
+		set: (key: string, state: StateValueType) => update((store) => upsert(store, key, state)),
+		reset: (value: { [key: string]: StateValueType }) => set(value)
 	};
 }
 

--- a/src/lib/types/journey.d.ts
+++ b/src/lib/types/journey.d.ts
@@ -186,3 +186,11 @@ export type DisplayValueStoreType =
 export type ValidationStoreType =
 	| { [key: string]: boolean }
 	| Record<{ [key: string]: boolean }, unknown>;
+export type StateRecordType = {
+	value: string; 
+	display: string; 
+	valid: boolean;
+}
+export type StateStoreType = 
+	| { [key: string]: StateRecordType } 
+	| Record<{ [key: string]: StateRecordType, unknown}>;

--- a/src/lib/types/journey.d.ts
+++ b/src/lib/types/journey.d.ts
@@ -186,11 +186,12 @@ export type DisplayValueStoreType =
 export type ValidationStoreType =
 	| { [key: string]: boolean }
 	| Record<{ [key: string]: boolean }, unknown>;
-export type StateRecordType = {
-	value: string; 
-	display: string; 
+
+export type StateValueType = {
+	value: string;
+	display: string;
 	valid: boolean;
-}
-export type StateStoreType = 
-	| { [key: string]: StateRecordType } 
-	| Record<{ [key: string]: StateRecordType, unknown}>;
+};
+export type StateStoreType =
+	| { [key: string]: StateValueType }
+	| Record<{ [key: string]: StateValueType; unknown }>;

--- a/src/lib/types/journey.d.ts
+++ b/src/lib/types/journey.d.ts
@@ -194,4 +194,4 @@ export type StateValueType = {
 };
 export type StateStoreType =
 	| { [key: string]: StateValueType }
-	| Record<{ [key: string]: StateValueType; unknown }>;
+	| Record<{ [key: string]: StateValueType }, unknown>;

--- a/src/lib/types/journey.d.ts
+++ b/src/lib/types/journey.d.ts
@@ -186,3 +186,12 @@ export type DisplayValueStoreType =
 export type ValidationStoreType =
 	| { [key: string]: boolean }
 	| Record<{ [key: string]: boolean }, unknown>;
+
+export type StateValueType = {
+	value: string;
+	display: string;
+	valid: boolean;
+};
+export type StateStoreType =
+	| { [key: string]: StateValueType }
+	| Record<{ [key: string]: StateValueType }, unknown>;

--- a/src/lib/utils/backofficevalidators.ts
+++ b/src/lib/utils/backofficevalidators.ts
@@ -113,7 +113,15 @@ export function component_ids_are_unique(journey: JourneyType): boolean {
  * Component ids must not contain full stops
  * This breaks the repeating group functionality
  */
-export function component_ids_do_not_contain_full_stops(journey: JourneyType): boolean {
+export function component_ids_do_not_contain_full_stop(journey: JourneyType): boolean {
+	// TODO: implement this
+	return true;
+}
+/**
+ * Component ids must not contain tildes
+ * This would clash with input identifiers
+ */
+ export function component_ids_do_not_contain_tilde(journey: JourneyType): boolean {
 	// TODO: implement this
 	return true;
 }

--- a/src/lib/utils/validators.ts
+++ b/src/lib/utils/validators.ts
@@ -15,20 +15,27 @@ import { to_section_list } from './converters';
  */
 export function component_valid(component: InputComponent, state: StateStoreType): boolean {
 	// (ineligible) - component has no identifier, it must be a display component only, we have no reason to validate
-	if (!component.id) return true;
+	if (!component.id) {
+		return true;
+	}
 
 	// (passed|failed) - input component has been attempted and has a validation status, trust this value
-	if (state[component.id]?.valid != null) return state[component.id]?.valid;
+	if (state[component.id]?.valid != null) {
+		return state[component.id]?.valid;
+	}
 
 	// (skipped) - component is optional and has been skipped, don't need to validate
-	if (!component.required ?? false) return true;
+	if (!component.required ?? false) {
+		return true;
+	}
 
 	// (hidden) - component is hidden due to dependency on another component, don't fail validation
 	if (
 		component.dependsupon &&
-		state[component.dependsupon.id]?.value != component.dependsupon.value
-	)
+		component.dependsupon.value != state[component.dependsupon.id]?.value
+	){
 		return true;
+	}
 
 	// (missing) - component has not been answered, yet is required and not hidden, so it must be invalid
 	return false;

--- a/src/lib/utils/validators.ts
+++ b/src/lib/utils/validators.ts
@@ -11,6 +11,37 @@ import type {
 import { to_section_list } from './converters';
 
 /**
+ * Establish whether a component's value is valid, trusting the component's judgement if provided
+ */
+export function component_valid(component: InputComponent, state: StateStoreType): boolean {
+	// (ineligible) - component has no identifier, it must be a display component only, we have no reason to validate
+	if (!component.id) return true;
+
+	// (passed|failed) - input component has been attempted and has a validation status, trust this value
+	if (state[component.id]?.valid != null) return state[component.id]?.valid;
+
+	// (skipped) - component is optional and has been skipped, don't need to validate
+	if (!component.required ?? false) return true;
+
+	// (hidden) - component is hidden due to dependency on another component, don't fail validation
+	if (
+		component.dependsupon &&
+		state[component.dependsupon.id]?.value != component.dependsupon.value
+	)
+		return true;
+
+	// (missing) - component has not been answered, yet is required and not hidden, so it must be invalid
+	return false;
+}
+
+/*
+TODO: 
+  - valueStore | validationStore | displayValueStore to be removed in favour of stateStore.
+  - functions to use snake_case as it is easier to read
+  - rework functions below here to meet the above, update/create tests, delete the rest
+*/
+
+/**
  * Establish the validity for a component, trusting the component's judgement if provided
  * @param component         Component metadata from journey.json used to establish validation criteria
  * @param valueStore        $valueStore from the SvelteKit runtime, or an object consisting of simple string key value pairs

--- a/src/test/components/inputtextbox.test.ts
+++ b/src/test/components/inputtextbox.test.ts
@@ -12,7 +12,7 @@ test('Textbox renders with only required properties', () => {
 		id: 'uniqueidentifier'
 	};
 	const { container } = render(InputTextbox, { component: component });
-	expect(container).toContainHTML('id="uniqueidentifier"');
+	expect(container).toContainHTML('id="uniqueidentifier-input"');
 });
 
 test('Textbox renders label correctly', () => {

--- a/src/test/components/inputtextbox.test.ts
+++ b/src/test/components/inputtextbox.test.ts
@@ -12,7 +12,7 @@ test('Textbox renders with only required properties', () => {
 		id: 'uniqueidentifier'
 	};
 	const { container } = render(InputTextbox, { component: component });
-	expect(container).toContainHTML('id="uniqueidentifier-input"');
+	expect(container).toContainHTML('id="uniqueidentifier~"');
 });
 
 test('Textbox renders label correctly', () => {

--- a/src/test/utils/validators.test.ts
+++ b/src/test/utils/validators.test.ts
@@ -1,5 +1,28 @@
 import type { InputComponent } from '$lib/types/journey';
-import { componentValid } from '$lib/utils/validators';
+import { componentValid, component_valid } from '$lib/utils/validators';
+
+test('InputComponent valid if state store says it is', () => {
+	const comp: InputComponent = {
+		id: '1',
+		type: 'Text'
+	};
+	const state: StateStoreType = {
+		'1': {
+			value: '',
+			display: '',
+			valid: true
+		}		
+	}
+	expect (component_valid(comp, state)).toBe(true);
+})
+// TODO: rework all below functions to use state store
+
+
+
+
+
+
+
 
 test('input provided, valid', () => {
 	const comp: InputComponent = {

--- a/static/technicaldemo/journey.json
+++ b/static/technicaldemo/journey.json
@@ -183,7 +183,7 @@
 						},
 						{
 							"type": "TriBoxDate",
-							"id": "purchaseDate",
+							"id": "purchaseDate2",
 							"label": "Enter future date",
 							"required": true,
 							"displayFormat": "long",


### PR DESCRIPTION
This is a big choice to make, but I think it produces cleaner, more well-defined component boundaries.
- Each component is responsible for pushing its own state directly to the store.
- Components also dispatch an event which can now become a simple key.
At this point everything is self-contained, communicating only via the store.
This solves the problem with validation scrolling and automatically highlighting the first error on the page, because this now all lives within the component itself.

If we're happy with this it will need rolling out to all base components as well as Component.svelte, many utility functions and actions, basically any reference to valueStore, validationStore and displayValueStore.
Some more notes relating to this on #103 